### PR TITLE
HW10 is completed

### DIFF
--- a/hw10_program_optimization/benchmark_results/new.txt
+++ b/hw10_program_optimization/benchmark_results/new.txt
@@ -1,0 +1,36 @@
+goos: linux
+goarch: amd64
+pkg: github.com/spmadness/otus-go-hw/hw10_program_optimization
+cpu: AMD Ryzen 7 5800H with Radeon Graphics         
+BenchmarkGetUsers-16         	    5005	    228431 ns/op	    9273 B/op	     121 allocs/op
+BenchmarkGetUsers-16         	    5059	    232128 ns/op	    9217 B/op	     119 allocs/op
+BenchmarkGetUsers-16         	    5104	    226643 ns/op	    9172 B/op	     118 allocs/op
+BenchmarkGetUsers-16         	    4945	    231734 ns/op	    9335 B/op	     122 allocs/op
+BenchmarkGetUsers-16         	    5064	    231191 ns/op	    9212 B/op	     119 allocs/op
+BenchmarkGetUsers-16         	    5102	    229324 ns/op	    9174 B/op	     118 allocs/op
+BenchmarkGetUsers-16         	    4964	    230176 ns/op	    9315 B/op	     122 allocs/op
+BenchmarkGetUsers-16         	    4959	    231417 ns/op	    9321 B/op	     122 allocs/op
+BenchmarkGetUsers-16         	    4916	    227245 ns/op	    9366 B/op	     123 allocs/op
+BenchmarkGetUsers-16         	    4957	    228547 ns/op	    9323 B/op	     122 allocs/op
+BenchmarkCountDomains-16     	     170	   6955918 ns/op	  559483 B/op	   22207 allocs/op
+BenchmarkCountDomains-16     	     175	   6818608 ns/op	  559488 B/op	   22208 allocs/op
+BenchmarkCountDomains-16     	     174	   6743279 ns/op	  559760 B/op	   22208 allocs/op
+BenchmarkCountDomains-16     	     174	   6973886 ns/op	  559715 B/op	   22208 allocs/op
+BenchmarkCountDomains-16     	     172	   6857874 ns/op	  559489 B/op	   22208 allocs/op
+BenchmarkCountDomains-16     	     174	   6891143 ns/op	  559620 B/op	   22207 allocs/op
+BenchmarkCountDomains-16     	     171	   7052754 ns/op	  559512 B/op	   22208 allocs/op
+BenchmarkCountDomains-16     	     166	   6907516 ns/op	  559904 B/op	   22207 allocs/op
+BenchmarkCountDomains-16     	     170	   7140221 ns/op	  560383 B/op	   22208 allocs/op
+BenchmarkCountDomains-16     	     172	   6971452 ns/op	  559884 B/op	   22207 allocs/op
+BenchmarkGetDomainStat-16    	    4904	    231212 ns/op	    9584 B/op	     130 allocs/op
+BenchmarkGetDomainStat-16    	    4798	    231400 ns/op	    9704 B/op	     132 allocs/op
+BenchmarkGetDomainStat-16    	    4720	    234336 ns/op	    9795 B/op	     135 allocs/op
+BenchmarkGetDomainStat-16    	    4321	    236071 ns/op	   10314 B/op	     147 allocs/op
+BenchmarkGetDomainStat-16    	    4975	    231011 ns/op	    9507 B/op	     128 allocs/op
+BenchmarkGetDomainStat-16    	    4923	    229256 ns/op	    9563 B/op	     129 allocs/op
+BenchmarkGetDomainStat-16    	    4852	    234430 ns/op	    9642 B/op	     131 allocs/op
+BenchmarkGetDomainStat-16    	    4845	    242135 ns/op	    9650 B/op	     131 allocs/op
+BenchmarkGetDomainStat-16    	    4714	    249782 ns/op	    9802 B/op	     135 allocs/op
+BenchmarkGetDomainStat-16    	    4572	    239154 ns/op	    9977 B/op	     139 allocs/op
+PASS
+ok  	github.com/spmadness/otus-go-hw/hw10_program_optimization	103.612s

--- a/hw10_program_optimization/benchmark_results/old.txt
+++ b/hw10_program_optimization/benchmark_results/old.txt
@@ -1,0 +1,36 @@
+goos: linux
+goarch: amd64
+pkg: github.com/spmadness/otus-go-hw/hw10_program_optimization
+cpu: AMD Ryzen 7 5800H with Radeon Graphics         
+BenchmarkGetUsers-16         	     715	   1538426 ns/op	  258043 B/op	    1824 allocs/op
+BenchmarkGetUsers-16         	     727	   1573502 ns/op	  253797 B/op	    1794 allocs/op
+BenchmarkGetUsers-16         	     728	   1569083 ns/op	  253450 B/op	    1792 allocs/op
+BenchmarkGetUsers-16         	     744	   1504774 ns/op	  248017 B/op	    1753 allocs/op
+BenchmarkGetUsers-16         	     744	   1502095 ns/op	  248017 B/op	    1753 allocs/op
+BenchmarkGetUsers-16         	     734	   1554756 ns/op	  251385 B/op	    1777 allocs/op
+BenchmarkGetUsers-16         	     730	   1518621 ns/op	  252758 B/op	    1787 allocs/op
+BenchmarkGetUsers-16         	     703	   1535417 ns/op	  262434 B/op	    1855 allocs/op
+BenchmarkGetUsers-16         	     724	   1530667 ns/op	  254846 B/op	    1801 allocs/op
+BenchmarkGetUsers-16         	     729	   1529311 ns/op	  253103 B/op	    1789 allocs/op
+BenchmarkCountDomains-16     	       7	 144900249 ns/op	139783862 B/op	 1844378 allocs/op
+BenchmarkCountDomains-16     	       8	 150376446 ns/op	139802473 B/op	 1844377 allocs/op
+BenchmarkCountDomains-16     	       7	 147311196 ns/op	139810070 B/op	 1844379 allocs/op
+BenchmarkCountDomains-16     	       7	 144187245 ns/op	139788555 B/op	 1844376 allocs/op
+BenchmarkCountDomains-16     	       7	 146376152 ns/op	139788758 B/op	 1844377 allocs/op
+BenchmarkCountDomains-16     	       7	 151336335 ns/op	139794166 B/op	 1844377 allocs/op
+BenchmarkCountDomains-16     	       8	 145265188 ns/op	139779597 B/op	 1844376 allocs/op
+BenchmarkCountDomains-16     	       7	 148997547 ns/op	139778146 B/op	 1844376 allocs/op
+BenchmarkCountDomains-16     	       7	 146286621 ns/op	139793972 B/op	 1844377 allocs/op
+BenchmarkCountDomains-16     	       7	 147910108 ns/op	139767714 B/op	 1844376 allocs/op
+BenchmarkGetDomainStat-16    	     456	   2224142 ns/op	  710960 B/op	    6904 allocs/op
+BenchmarkGetDomainStat-16    	     469	   2239255 ns/op	  691356 B/op	    6713 allocs/op
+BenchmarkGetDomainStat-16    	     466	   2156616 ns/op	  695724 B/op	    6756 allocs/op
+BenchmarkGetDomainStat-16    	     463	   2178759 ns/op	  700303 B/op	    6800 allocs/op
+BenchmarkGetDomainStat-16    	     487	   2108681 ns/op	  665760 B/op	    6465 allocs/op
+BenchmarkGetDomainStat-16    	     574	   1977136 ns/op	  565052 B/op	    5486 allocs/op
+BenchmarkGetDomainStat-16    	     511	   2045312 ns/op	  634461 B/op	    6162 allocs/op
+BenchmarkGetDomainStat-16    	     500	   2004259 ns/op	  648473 B/op	    6297 allocs/op
+BenchmarkGetDomainStat-16    	     488	   2072350 ns/op	  664320 B/op	    6452 allocs/op
+BenchmarkGetDomainStat-16    	     538	   2064918 ns/op	  602733 B/op	    5853 allocs/op
+PASS
+ok  	github.com/spmadness/otus-go-hw/hw10_program_optimization	133.321s

--- a/hw10_program_optimization/go.mod
+++ b/hw10_program_optimization/go.mod
@@ -1,4 +1,4 @@
-module github.com/fixme_my_friend/hw10_program_optimization
+module github.com/spmadness/otus-go-hw/hw10_program_optimization
 
 go 1.19
 

--- a/hw10_program_optimization/stats_benchmark_test.go
+++ b/hw10_program_optimization/stats_benchmark_test.go
@@ -1,0 +1,85 @@
+//go:build bench
+// +build bench
+
+package hw10programoptimization
+
+import (
+	"archive/zip"
+	"io"
+	"testing"
+)
+
+func BenchmarkGetUsers(b *testing.B) {
+	b.StopTimer()
+
+	data, err := getDataFile()
+	if err != nil {
+		b.Errorf("data file open error: %v", err)
+	}
+
+	defer func(data io.ReadCloser) {
+		err = data.Close()
+		if err != nil {
+			b.Errorf("data file close error: %v", err)
+		}
+	}(data)
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = getUsers(data)
+	}
+}
+
+func BenchmarkCountDomains(b *testing.B) {
+	b.StopTimer()
+	data, err := getDataFile()
+	if err != nil {
+		b.Errorf("data file open error: %v", err)
+	}
+
+	defer func(data io.ReadCloser) {
+		err = data.Close()
+		if err != nil {
+			b.Errorf("data file close error: %v", err)
+		}
+	}(data)
+
+	u, err := getUsers(data)
+	if err != nil {
+		b.Errorf("get users error: %v", err)
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = countDomains(u, "biz")
+	}
+}
+
+func BenchmarkGetDomainStat(b *testing.B) {
+	b.StopTimer()
+	data, err := getDataFile()
+	if err != nil {
+		b.Errorf("data file open error: %v", err)
+	}
+	defer func(data io.ReadCloser) {
+		err = data.Close()
+		if err != nil {
+			b.Errorf("data file close error: %v", err)
+		}
+	}(data)
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = GetDomainStat(data, "biz")
+	}
+}
+
+func getDataFile() (io.ReadCloser, error) {
+	r, _ := zip.OpenReader("testdata/users.dat.zip")
+	data, err := r.File[0].Open()
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/hw10_program_optimization/stats_test.go
+++ b/hw10_program_optimization/stats_test.go
@@ -1,9 +1,11 @@
+//go:build !bench
 // +build !bench
 
 package hw10programoptimization
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,4 +38,23 @@ func TestGetDomainStat(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, DomainStat{}, result)
 	})
+
+	t.Run("invalid json given", func(t *testing.T) {
+		var jsErr *json.SyntaxError
+		data = `{"Id":1,"Name":"Howard Mendoza","Username":"0Oliver","Email":"`
+
+		_, err := GetDomainStat(bytes.NewBufferString(data), "biz")
+		require.ErrorAsf(t, err, &jsErr, "error: %s, target: %s", err, &jsErr)
+	})
+
+	t.Run("nil reader given", func(t *testing.T) {
+		_, err := GetDomainStat(nil, "biz")
+		require.ErrorIsf(t, err, ErrNilReader, "error: %s, target: %s", err, ErrNilReader)
+	})
+
+	t.Run("empty reader data given", func(t *testing.T) {
+		_, err := GetDomainStat(bytes.NewBufferString(""), "biz")
+		require.ErrorIsf(t, err, ErrEmptySourceData, "error: %s, target: %s", err, ErrEmptySourceData)
+	})
+
 }


### PR DESCRIPTION
Benchmarks:

goos: linux
goarch: amd64
pkg: github.com/spmadness/otus-go-hw/hw10_program_optimization
cpu: AMD Ryzen 7 5800H with Radeon Graphics

                 │ benchmark_results/old.txt │      benchmark_results/new.txt      │
                 │          sec/op           │   sec/op     vs base                │

  GetUsers-16                     1533.0µ ± 2%   229.8µ ± 1%  -85.01% (p=0.000 n=10)
CountDomains-16                146.844m ± 2%   6.932m ± 2%  -95.28% (p=0.000 n=10)
GetDomainStat-16                2090.5µ ± 6%   234.4µ ± 3%  -88.79% (p=0.000 n=10)
geomean                          7.778m        720.0µ       -90.74%

                 │ benchmark_results/old.txt │      benchmark_results/new.txt       │
                 │           B/op            │     B/op      vs base                │

GetUsers-16                   247.340Ki ± 2%   9.076Ki ± 1%  -96.33% (p=0.000 n=10)
CountDomains-16              136512.4Ki ± 0%   546.6Ki ± 0%  -99.60% (p=0.000 n=10)
GetDomainStat-16              649.453Ki ± 9%   9.450Ki ± 3%  -98.54% (p=0.000 n=10)
geomean                         2.733Mi        36.06Ki       -98.71%

                 │ benchmark_results/old.txt │      benchmark_results/new.txt      │
                 │         allocs/op         │  allocs/op   vs base                │

GetUsers-16                      1790.5 ± 2%    121.5 ± 3%  -93.21% (p=0.000 n=10)
CountDomains-16                1844.38k ± 0%   22.21k ± 0%  -98.80% (p=0.000 n=10)
GetDomainStat-16                 6458.5 ± 9%    131.5 ± 6%  -97.96% (p=0.000 n=10)
geomean                          27.73k         708.0       -97.45%
